### PR TITLE
bulkcreate를 통해 그룹,유저 맵핑 시도

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3,6 +3,7 @@ var express = require('express');
 var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
+var bodyParser = require('body-parser');
 
 
 
@@ -28,6 +29,8 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+app.use(bodyParser.urlencoded({extended:false}));
+app.use(bodyParser.json());
 
 app.use('/api',require('./routes/api'));
 // catch 404 and forward to error handler

--- a/backend/models/friend.js
+++ b/backend/models/friend.js
@@ -6,7 +6,7 @@ module.exports = (sequelize,DataTypes)=>{
             type:DataTypes.UUID,
             references:{
                 model:'users',
-                key:'userId'
+                key:'id'
             }
         },
         hidden:{

--- a/backend/models/group.js
+++ b/backend/models/group.js
@@ -3,7 +3,7 @@ const User = require("./user")
 
 module.exports = (sequelize,DataTypes)=>{
     return sequelize.define('group',{
-        groupId:{
+        id:{
             type:DataTypes.UUID,
             allowNull:false,
             unique:true,

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -49,16 +49,13 @@ db.Group=require('./group')(sequelize,Sequelize);
 db.Friend=require('./friend')(sequelize,Sequelize);
 db.Store=require('./store')(sequelize,Sequelize);
 db.Visit=require('./visit')(sequelize,Sequelize);
+db.Member=require('./member')(sequelize,Sequelize);
 
-  
-
-db.User.hasMany(db.Group)
 db.User.hasMany(db.Friend)
 db.User.hasMany(db.Visit)
 
 db.Store.hasMany(db.Visit)
 
-db.Group.belongsTo(db.User)
 db.Friend.belongsTo(db.User)
 db.Visit.belongsTo(db.User)
 

--- a/backend/models/member.js
+++ b/backend/models/member.js
@@ -1,0 +1,18 @@
+module.exports = (sequelize,DataTypes)=>{
+    return sequelize.define("member",{
+        groupId:{
+            type:DataTypes.UUID,
+            references:{
+                model:'groups',
+                key:'id'
+            }
+        },
+        userId:{
+            type:DataTypes.UUID,
+            references:{
+                model:'users',
+                key:'id'
+            }
+        }
+    })
+}

--- a/backend/models/store.js
+++ b/backend/models/store.js
@@ -2,7 +2,7 @@ const { Sequelize } = require(".");
 
 module.exports = (sequelize,DataTypes)=>{
     return sequelize.define('store',{
-        storeId:{
+        id:{
             type:DataTypes.UUID,
             primaryKey:true,
             allowNull:false,

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -4,7 +4,7 @@ const { Sequelize } = require(".");
 
 module.exports = (sequelize,DataTypes)=>{
     return sequelize.define('user',{
-        userId:{
+        id:{
             type:DataTypes.UUID,
             allowNull:false,
             primaryKey: true,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.0.1",
+        "body-parser": "^1.18.3",
         "cookie-parser": "~1.4.4",
         "debug": "~2.6.9",
         "express": "~4.16.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "bcrypt": "^5.0.1",
+    "body-parser": "^1.18.3",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "express": "~4.16.1",

--- a/backend/routes/api/user/controller.js
+++ b/backend/routes/api/user/controller.js
@@ -32,9 +32,39 @@ exports.getUser = (req,res,next)=>{
         if((data==null || data==undefined)==false){
             res.json({
                 success:true,
-                userlist:data
+                data:data
             })
         }
     })
    
+}
+
+exports.makeGroup = (req,res,next)=>{
+    model.Group.create({
+        groupName:req.body.groupName,
+        createdAt:new Date().getTime(),
+        updatedAt:new Date().getTime()
+    })
+    .then(result=>{
+        res.json({
+            success:true,
+            data:result
+        })
+    })
+}
+
+exports.makeMember = (req,res,next)=>{
+    model.Member.bulkCreate(req.body,{returning:true})
+    .then(result=>{
+        res.json({
+            success:true,
+            data:result
+        })
+    })
+    .catch(err=>{
+        res.status(404).json({
+            success:false,
+            message:err
+        })
+    })
 }

--- a/backend/routes/api/user/index.js
+++ b/backend/routes/api/user/index.js
@@ -3,5 +3,7 @@ const controller = require('./controller')
 
 router.post('/signup',controller.register)
 router.post('/get-user',controller.getUser)
+router.post('/edit-group',controller.makeGroup)
+router.post('/make-member',controller.makeMember)
 
 module.exports = router


### PR DESCRIPTION
기존 group 테이블에 userId를 포함했었는데 그렇게 안하고 member라는 테이블을 추가하여 그 테이블에 유저아이디와 그룹 아이디를 맵핑하는 구조로 만들었다. 그리고 그룹을 만들 때 우선 방을 만들고 나서 그 다음에 멤버를 추가하는 형식으로 한다고 가정했을 때  'edit-group' --> 'make-member' 순으로 api url을 불러오면 될 것 같다.